### PR TITLE
Renamed sys to util and declared a variable with var

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -76,7 +76,7 @@ var parseLessFile = function(input, output){
                 try {
                     var css = tree.toCSS({ compress: options.compress });
                     if (output) {
-                        fd = fs.openSync(output, "w");
+                        var fd = fs.openSync(output, "w");
                         fs.writeSync(fd, css, 0, "utf8");
                     } else {
                         util.print(css);


### PR DESCRIPTION
Hey I use watch-less from time to time. Every time I start it it will display a warning about sys being called util now (and that it has a similar interface). I've done a quick search and replace.

Also, I've declared a variable with a var, so that it will only exist in its own scope. This could prevent some future headaches.

Cheers and thank you for watch-less.
