### PR TITLE
Compile .less file on startup

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -121,6 +121,9 @@ walker.on('file', function(root, fileStats, next) {
     if(/.*\.(less)$/.test(fileStats.name)){
         var filePath = path.resolve(root, fileStats.name);
 
+        // Compile .less file on startup:
+        compileLessFile(filePath);
+
         fs.watchFile(filePath, function(curr, prev){
             compileLessFile(filePath);
         });


### PR DESCRIPTION
Scratching an itch raised in issue #7. It was getting irritating having to run `find . -name '*.less' | xargs touch` after every time I started watch-less :-)

Since this consitutes a behaviour change it may be worth bumping the version number.
