### PR TITLE
Ignore files starting with an underscore

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -118,7 +118,7 @@ walker.on('directories', function(root, dirStatsArray, next) {
 });
 
 walker.on('file', function(root, fileStats, next) {
-    if(/.*\.(less)$/.test(fileStats.name)){
+    if(/.*\.(less)$/.test(fileStats.name) && fileStats.name.indexOf("_") != 0){
         var filePath = path.resolve(root, fileStats.name);
 
         // Compile .less file on startup:


### PR DESCRIPTION
It's a fairly common thing to ignore less files starting with an underscore, as these can be used as partials that you don't want individually compiled.
