### PR TITLE
Fix directory ignore

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -106,10 +106,14 @@ var compileLessFile = function(lessFile) {
 
 var walker = walk.walk(rootDirectory, { followLinks: false });
 
-walker.on('directory', function(root, dirStatsArray, next) {
-    if(ignoreList.indexOf(dirStatsArray.name) === -1){
-        next();
-    }
+walker.on('directories', function(root, dirStatsArray, next) {
+    dirStatsArray.forEach(function (dirStats, index, arr) {
+        if (ignoreList.indexOf(dirStats.name) !== -1) {
+            arr.splice(index, 1);
+            console.log('Ignoring: ', dirStats.name);
+        }
+    });
+    next();
 });
 
 walker.on('file', function(root, fileStats, next) {

--- a/cli.js
+++ b/cli.js
@@ -106,7 +106,7 @@ var compileLessFile = function(lessFile) {
 
 var walker = walk.walk(rootDirectory, { followLinks: false });
 
-walker.on('directories', function(root, dirStatsArray, next) {
+walker.on('directory', function(root, dirStatsArray, next) {
     if(ignoreList.indexOf(dirStatsArray.name) === -1){
         next();
     }


### PR DESCRIPTION
In the old version, `dirStatsArray` is an array of maps containing a name property.

In this PR, `dirStatsArray` is an map containing a `name` property, so ignoring works like expected.